### PR TITLE
Incorporate Noah's edits

### DIFF
--- a/reports/manuscript/sections/methods.tex
+++ b/reports/manuscript/sections/methods.tex
@@ -84,62 +84,71 @@ feature's mean and scale it to unit variance. Scaling is performed separately
 within each cross-validation set's training or testing data to prevent leakage
 of information between the testing and training sets\cite{kaufman2012leakage}.
 
-After scaling and imputation, the tractometry data and target phenotypical data
-can be organized in a linear model:
-
+After scaling and imputation, the tractometry data and target
+phenotypical data can be organized in a linear model:
 \begin{equation}
-y = \mathbf{X} \cdot \beta,
-\label{eq:lm}
+    y = \mathbf{X} \beta + \epsilon,
+    \label{eq:lm}
 \end{equation}
-
-where $y$ is the phenotype -- categorical, such as a clinical diagnosis, or
-continuous numerical, such as the subject's age. The tractometry data is
-represented in the feature matrix $\mathbf{X}$, with rows corresponding to
-different subjects, and columns corresponding to diffusion measures at different
-nodes within each tract. The relationship between tractometric features and the
-phenotypic target is characterized by the coefficients in $\beta$. In general,
-the feature matrix $\mathbf{X}$ has dimensions $S \times (T \cdot N \cdot M)$,
-where $S$ is the number of subjects, $T$ is the number of white matter tracts,
-$N$ is the number of nodes in each tract, and $M$ is the number of diffusion
-metrics calculated at each node. Typically, $T = 20$, $N = 100$, and $2 \le M
-\le 8$, resulting in $\sim 4,000 - 16,000$  features. Conversely, many dMRI
-studies have between a few dozen and a few hundred subjects, yielding a feature
-matrix that is wide and short. Even in cases where more than a thousand subjects
-are measured (e.g., in the Human Connectome Project, where 1,200 subjects were
-measured \cite{VanEssen2012}), the problem is ill-posed: the high dimensionality
+where $y$ is the phenotype -- categorical, such as a clinical diagnosis,
+or continuous numerical, such as the subject's age. The tractometry
+data is represented in the feature matrix $\mathbf{X}$, with rows
+corresponding to different subjects, and columns corresponding
+to diffusion measures at different nodes within each tract. The
+relationship between tractometric features and the phenotypic target is
+characterized by the coefficients in $\beta$. The error term, $\epsilon$
+is an unobserved random variable that captures the error in the model.
+We denote our prediction of the targer phenotype as $\hat{y}$ and the
+coefficients that produce this prediction as $\hat{\beta}$, so that
+\begin{equation}
+    \hat{y} = \mathbf{X} \hat{\beta},
+    \label{eq:lm-approx}
+\end{equation}
+without the error term, $\epsilon$. In general, the feature matrix
+$\mathbf{X}$ has dimensions $S \times (T \times N \times M)$, where $S$
+is the number of subjects, $T$ is the number of white matter tracts,
+$N$ is the number of nodes in each tract, and $M$ is the number of
+diffusion metrics calculated at each node. Typically, $T = 20$, $N =
+100$, and $2 \le M \le 8$, resulting in $\sim 4,000 - 16,000$ features.
+Conversely, many dMRI studies have between a few dozen and a few
+hundred subjects, yielding a feature matrix that is wide and short.
+Even in cases where more than a thousand subjects are measured (e.g.,
+in the Human Connectome Project, where 1,200 subjects were measured
+\cite{VanEssen2012}), the problem is ill-posed: the high dimensionality
 of this data requires regularization to avoid overfitting and generate
 interpretable results.
 
-Here, we propose that in addition to regularizing the coefficients in $\beta$,
-we can also capitalize on our knowledge of the group structure of the tract
-profile features in $\mathbf{X}$. The tract-metric combinations form a natural
-grouping. For example, we expect that MD features within the left arcuate
-fasciculus will co-vary across individuals. Likewise for FA values within the
-right corticospinal tract (CST) and so on. This group structure is represented
-in Fig~\ref{fig:group-structure}, which depicts the linear model $y = \mathbf{X}
-\cdot \beta$. Thus, we seek a regularization approach that will fit a linear
-model with anatomically-grouped covariates, where we expect to observe both
-groupwise sparsity, where the number of groups (tract/metric combinations) with
-at least one non-zero coefficients is small, as well as within-group sparsity,
-where the number of non-zero coefficients within each non-zero group is small.
-The sparse group lasso (SGL)
-is a penalized regression technique that satisfies exactly these
-criteria\cite{simon2013sparse}. It solves for a coefficient vector
+Here, we propose that in addition to regularizing the coefficients
+in $\hat{\beta}$, we can also capitalize on our knowledge of the
+group structure of the tract profile features in $\mathbf{X}$. The
+tract-metric combinations form a natural grouping. For example, we
+expect that MD features within the left arcuate fasciculus will
+co-vary across individuals. Likewise for FA values within the right
+corticospinal tract (CST) and so on. This group structure is represented
+in Fig~\ref{fig:group-structure}, which depicts the linear model
+$\hat{y} = \mathbf{X} \hat{\beta}$. Thus, we seek a regularization
+approach that will fit a linear model with anatomically-grouped
+covariates, where we expect to observe both groupwise sparsity, where
+the number of groups (tract/metric combinations) with at least one
+non-zero coefficients is small, as well as within-group sparsity, where
+the number of non-zero coefficients within each non-zero group is small.
+The sparse group lasso (SGL) is a penalized regression technique that
+satisfies exactly these criteria\cite{simon2013sparse}. It solves for a
+coefficient vector
 $\hat{\beta}$ that satisfies
 \begin{equation}
     \hat{\beta} = \min_\beta \frac{1}{2}
     ||y - \displaystyle \sum_{\ell = 1}^{G}
-    \mathbf{X}^{(\ell)} \cdot \beta^{(\ell)}||_2^2
+    \mathbf{X}^{(\ell)} \beta^{(\ell)}||_2^2
     + \lambda_1 \displaystyle \sum_{\ell = 1}^{G}
     \sqrt{p_\ell} ||\beta^{(\ell)}||_2
     + \lambda_2 ||\beta||_1,
     \label{eq:sgl}
 \end{equation}
-
 where $G$ is the number of groups $\mathbf{X}^{(\ell)}$ is the submatrix
 of $\mathbf{X}$ corresponding to group $\ell$, $\beta^{(\ell)}$ is
 the coefficient vector for group $\ell$ and $p_\ell$ is the length of
-$\beta^{(\ell)}$. In the tractomtetry setting, $G = T \cdot M$ and
+$\beta^{(\ell)}$. In the tractomtetry setting, $G = T \times M$ and
 $\forall \ell: p_\ell = 100$. The first term is the mean square error
 loss, $L_{\text{mse}}$, as in the standard linear regression framework.
 The second and third terms encourage groupwise sparsity and overall
@@ -152,35 +161,40 @@ the group lasso\cite{yuan2006model}.
     \centering
     \includegraphics[width=0.65\textwidth]{dMRI_group_structure.png}
     \caption{{\bf dMRI group structure.}
-        The phenotypical target data and tractometric features can be organized
-    into a linear model, $y = \mathbf{X} \cdot \beta$. The feature matrix
-    $\mathbf{X}$ is color-coded to reveal a natural group structure: the left
-    (orange) group contains $k$ features from the inferior fronto-occipital
-    fascicle (IFOF), the middle (green) group contains $k$ features from the
-    corpus callosum, and the right (blue) group contains $k$ features from the
-    uncinate. The coefficients in $\beta$ follow the same natural grouping.
-    Fascicle image reproduced with permission from Ref~\cite{yeatman2012tract}
-    Figure 1.}
+        The phenotypical target data and tractometric features can
+        be organized into a linear model, $\hat{y} = \mathbf{X}
+        \hat{\beta}$. The feature matrix $\mathbf{X}$ is color-coded
+        to reveal a natural group structure: the left (orange) group
+        contains $k$ features from the inferior fronto-occipital
+        fascicle (IFOF), the middle (green) group contains $k$ features
+        from the corpus callosum, and the right (blue) group
+        contains $k$ features from the uncinate. The coefficients in
+        $\hat{\beta}$ follow the same natural grouping. Fascicle image
+        reproduced with permission from Ref~\cite{yeatman2012tract}
+        Figure 1.
+    }
     \label{fig:group-structure}
 \end{figure}
 
 
 \subsubsection*{Incorporating transformations on $y$}
 
-Often, the target variable $y$ is not in the domain in which the linear model
-can be best fit to it. Equation \ref{eq:lm} can be slightly modified as:
+Often, the target variable $y$ is not in the domain in which the linear
+model can be best fit to it. Equation \ref{eq:lm-approx} can be slightly
+modified as:
 \begin{equation}
-y = f^-1(\mathbf{X} \cdot \beta),
-\label{eq:lm}
+    \hat{y} = f^-1(\mathbf{X} \hat{\beta}),
+    \label{eq:lm-transform}
 \end{equation}
-where the transformation function $f^{-1}$ characterizes the transform applied
-to the data before fitting the linear coefficients. For example, an often-used
-transform is the logarithmic transform:
+where the transformation function $f^{-1}$ characterizes the transform
+applied to the data before fitting the linear coefficients. For example,
+an often-used transform is the logarithmic transform:
 \begin{equation}
-f(y) = \log_n(y)
-\label{eq:log_nonlinearity}
+    f(\hat{y}) = \log_n(\hat{y})
+    \label{eq:log-nonlinearity}
 \end{equation}
-In this case, the model is parametrized by one additional fit parameter, $n$.
+In this case, the model is parametrized by one additional fit parameter,
+$n$.
 
 \subsubsection*{Classification of categorical $y$}
 When the phenotypical target variable is categorical, as in the case of
@@ -189,7 +203,7 @@ readily adapted to logistic regression, where the probability of a target
 variable belonging to an arbitrary defined ``true'' class is the logistic
 function of the result of the linear model,
 \begin{equation}
-    p(y = 1) = \frac{1}{1 + \exp(\mathbf{X}\cdot \beta)},
+    p(\hat{y} = 1) = \frac{1}{1 + \exp(\mathbf{X} \hat{\beta})},
     \label{eq:logit}
 \end{equation}
 or equivalently, the mean squared error loss function in Eq~\eqref{eq:sgl} is
@@ -224,7 +238,7 @@ train\textsubscript{inner} set. At level-1 of the decomposition, we fit an SGL
 model using fixed regularization meta-parameters $\lambda_1$ and $\lambda_2$,
 training the model using train\textsubscript{inner} and evaluating the fit on
 test\textsubscript{inner}. We find the optimal values for $\lambda_1$ and
-$\lambda_2$ using hyperoptimizatin. This is implemented using the hyperopt
+$\lambda_2$ using hyperoptimization, implemented using the hyperopt
 library's \verb|fmin| function\cite{Bergstra_2015} with a tree of Parzen
 estimators search algorithm\cite{bergstra2011algorithms}. For continuous
 numerical $y$, \verb|fmin| searches for meta-parameter values that minimize the


### PR DESCRIPTION
This PR addresses @nrs02004's edits to the paper. In particular, it adds an error term to the definition of the linear model and uses y-hat and beta-hat afterward to represent predictions. Thanks @nrs02004.